### PR TITLE
implement zxcvbn load issue by loading it via an internal html import

### DIFF
--- a/gold-password-input-strength-meter.html
+++ b/gold-password-input-strength-meter.html
@@ -8,6 +8,8 @@
 
 <link rel="import" href="./gold-password-input-icons.html">
 
+<link rel="import" href="./zxcvbn.html">
+
 <!--
 `<gold-password-input-strength-meter>` is a password strength meter for use with
 `<gold-password-input>`. It shows the strength of the password entered in the input.
@@ -103,7 +105,7 @@ Custom property | Description | Default
   </template>
   <script>
     (function() {
-      var isZxcvbnLoaded = false;
+      // var isZxcvbnLoaded = false;
 
       Polymer({
         is: 'gold-password-input-strength-meter',
@@ -156,20 +158,20 @@ Custom property | Description | Default
           }
         },
 
-        ready: function() {
-          isZxcvbnLoaded = typeof zxcvbn !== "undefined";
-          if (!isZxcvbnLoaded) {
-            isZxcvbnLoaded = true;
-            var oScript = document.createElement("script");
-            oScript.type = "text\/javascript";
-            oScript.onerror = function(err) {
-              isZxcvbnLoaded = false;
-              throw new URIError("The script " + err.target.src + " is not accessible.");
-            };
-            this.parentNode.insertBefore(oScript, this);
-            oScript.src = this.resolveUrl("../zxcvbn/dist/zxcvbn.js");
-          }
-        },
+        // ready: function() {
+        //   isZxcvbnLoaded = typeof zxcvbn !== "undefined";
+        //   if (!isZxcvbnLoaded) {
+        //     isZxcvbnLoaded = true;
+        //     var oScript = document.createElement("script");
+        //     oScript.type = "text\/javascript";
+        //     oScript.onerror = function(err) {
+        //       isZxcvbnLoaded = false;
+        //       throw new URIError("The script " + err.target.src + " is not accessible.");
+        //     };
+        //     this.parentNode.insertBefore(oScript, this);
+        //     oScript.src = this.resolveUrl("../zxcvbn/dist/zxcvbn.js");
+        //   }
+        // },
 
         update: function(state) {
           // FIXME PG: suppress when paper-input-container has reflectToAttribute for invalid... cf. ( https://github.com/PolymerElements/paper-input/pull/258 )
@@ -187,9 +189,9 @@ Custom property | Description | Default
             return;
           }
 
-          if (!isZxcvbnLoaded) {
-            return;
-          }
+          // if (!isZxcvbnLoaded) {
+          //   return;
+          // }
 
           // Use zxcvbn to evaluate the strength of the password.
           var result = zxcvbn(state.value);

--- a/zxcvbn.html
+++ b/zxcvbn.html
@@ -1,0 +1,1 @@
+<script src="../zxcvbn/dist/zxcvbn.js"></script>


### PR DESCRIPTION
I was encountering issues with zxcvbn not getting loaded correctly with the previous load code. As the title says, I have moved zxcvbn into an .html import which is loaded and run before the element is marked as ready.

this is for the v1 release